### PR TITLE
fix: git-semver-tags not working due to improper tagging of releases #14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -427,7 +427,7 @@
                     <artifactId>maven-scm-plugin</artifactId>
                     <version>${org.apache.maven-scm-plugin.version}</version>
                     <configuration>
-                        <tag>${project.artifactId}-${project.version}</tag>
+                        <tag>${project.version}</tag>
                     </configuration>
                 </plugin>
 


### PR DESCRIPTION
PR for #14.

Changed the configuration tag. It was versioning the releases incorrectly. 