### PR TITLE
feat: Add pass/fail SauceLabs test status when reporting results

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -132,6 +132,11 @@
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-surefire-provider</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.saucelabs</groupId>
+            <artifactId>saucerest</artifactId>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/framework/src/main/java/io/github/kgress/scaffold/extensions/SauceExtension.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/extensions/SauceExtension.java
@@ -1,0 +1,54 @@
+package io.github.kgress.scaffold.extensions;
+
+import com.saucelabs.saucerest.SauceREST;
+import io.github.kgress.scaffold.webdriver.TestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+public class SauceExtension implements BeforeAllCallback, TestWatcher {
+
+    private SauceREST sauce;
+
+    @BeforeEach
+    public void beforeAll(ExtensionContext context) throws Exception {
+        try {
+            var environment = SpringExtension.getApplicationContext(context).getEnvironment();
+            var sauceUsername = environment.getProperty("desired-capabilities.sauce.user-name");
+            var sauceAccessKey = environment.getProperty("desired-capabilities.sauce.access-key");
+            sauce = new SauceREST(sauceUsername, sauceAccessKey);
+        } catch (Exception e) {
+            throw new Exception("Error initializing the Sauce Labs API: Please check your configuration to ensure the username and password are not null.");
+        }
+    }
+
+    @Override
+    public void testDisabled(ExtensionContext context, Optional<String> reason) {
+        // TODO what to do with disabled test?
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        sauce.jobPassed(getSessionId());
+    }
+
+    @Override
+    public void testAborted(ExtensionContext context, Throwable cause) {
+        sauce.jobFailed(getSessionId());
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        sauce.jobFailed(getSessionId());
+    }
+
+    private String getSessionId() {
+        return TestContext.baseContext().getSetting(String.class, "SESSION_ID");
+    }
+}

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/BaseTestContext.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/BaseTestContext.java
@@ -43,7 +43,7 @@ public class BaseTestContext {
      * @param key the key to add
      * @param value the value to add
      */
-    private void addSetting(String key, Object value) {
+    public void addSetting(String key, Object value) {
         settings.put(key, value);
     }
 

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/WebDriverManager.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/WebDriverManager.java
@@ -66,6 +66,7 @@ public class WebDriverManager {
     private Set<Cookie> cookieJar = new TreeSet<>();
     private RunType runType;
     private BrowserType browserType;
+    private String sessionId;
 
     @Autowired
     public WebDriverManager(DesiredCapabilitiesConfigurationProperties desiredCapabilities,
@@ -124,6 +125,10 @@ public class WebDriverManager {
      */
     public WebDriverWrapper getWebDriverWrapper() {
         return webDriverWrapper;
+    }
+
+    public String getSessionId() {
+        return sessionId;
     }
 
     /**
@@ -296,7 +301,7 @@ public class WebDriverManager {
     private WebDriver configureRemoteBrowser(MutableCapabilities browserOptions, String testName) {
         var browserVersion = desiredCapabilities.getBrowserVersion();
         var runPlatform = desiredCapabilities.getRunPlatform();
-        RemoteWebDriver remoteWebriver;
+        RemoteWebDriver remoteWebDriver;
 
         // If the test is using GRID but the browserOptions are null, throw an error. We must have DesiredCapabilitiesConfigurationProperties configured.
         if (browserOptions == null) {
@@ -313,9 +318,11 @@ public class WebDriverManager {
             browserOptions.setCapability("platform", runPlatform);
         }
 
-        remoteWebriver = createRemoteWebDriver(browserOptions, testName);
-        checkIfGridAndSendGridRequest(remoteWebriver);
-        return remoteWebriver;
+        remoteWebDriver = createRemoteWebDriver(browserOptions, testName);
+        sessionId = remoteWebDriver.getSessionId().toString();
+        TestContext.baseContext().addSetting("SESSION_ID", sessionId);
+        checkIfGridAndSendGridRequest(remoteWebDriver);
+        return remoteWebDriver;
     }
 
     /**

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/interfaces/TestContextSetting.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/interfaces/TestContextSetting.java
@@ -10,6 +10,7 @@ public interface TestContextSetting {
     String QUEUE_HOST = "queue_host";
     String QUEUE_NAME = "queue_name";
     String TEST_RUN_ID = "test_run_id";
+    String SESSION_ID = "SESSION_ID";
     String TEST_APPLICATION_CONTEXT = "test_application_context";
     String WAIT_CONDITION = "wait_condition";
     String WAIT_FOR_DISPLAY_ENABLED = "wait_for_display_enabled";

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <org.junit.jupiter.api.version>5.4.1</org.junit.jupiter.api.version>
         <org.junit.jupiter.platform.version>1.4.1</org.junit.jupiter.platform.version>
         <org.junit.platform.surefire-provider.version>1.3.2</org.junit.platform.surefire-provider.version>
+        <com.saucelabs.sauce-junit>2.1.21</com.saucelabs.sauce-junit>
 
         <!--Plugins-->
         <org.apache.maven-scm-plugin.version>1.11.1</org.apache.maven-scm-plugin.version>
@@ -283,6 +284,12 @@
                 <groupId>org.jboss.spec.javax.transaction</groupId>
                 <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                 <version>1.1.1.Final</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.saucelabs</groupId>
+                <artifactId>saucerest</artifactId>
+                <version>1.0.42</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Pr for #5 

* Created a `SauceExtension` that can be pulled into a test project's BaseTest file with ```@ExtendWith(SauceExtension.class)```. This extension will handle test reporting to the sauce labs api so the dashboard will show test results.
* Added a sessionId `TestContextSetting`
* Updated the addSetting method in the `BaseTestContext` file to support adding a session id from other classes
* Random typo fix