### PR TITLE
feat: QOL code improvements

### DIFF
--- a/environment/src/main/java/io/github/kgress/scaffold/environment/config/DesiredCapabilitiesConfigurationProperties.java
+++ b/environment/src/main/java/io/github/kgress/scaffold/environment/config/DesiredCapabilitiesConfigurationProperties.java
@@ -3,10 +3,13 @@ package io.github.kgress.scaffold.environment.config;
 import io.github.kgress.scaffold.models.enums.BrowserType;
 import io.github.kgress.scaffold.models.enums.Platform;
 import io.github.kgress.scaffold.models.enums.RunType;
+import io.github.kgress.scaffold.models.enums.ScreenResolution;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.NotNull;
+
+import static io.github.kgress.scaffold.models.enums.ScreenResolution.SIZE_1024x1080;
 
 /**
  * This model depicts the many Desired Capabilities of a Selenium WebDriver browser. This is used as an auto configuration
@@ -27,6 +30,7 @@ public class DesiredCapabilitiesConfigurationProperties {
     private String remoteUrl;
     private String browserVersion = ""; // Empty represents latest version
     private Platform runPlatform;
+    private ScreenResolution screenResolution = SIZE_1024x1080; // default screen size
     private boolean uploadScreenshots = false;
     private boolean useProxy = false;
     private final SauceContext sauce = new SauceContext();
@@ -63,6 +67,10 @@ public class DesiredCapabilitiesConfigurationProperties {
         return useProxy;
     }
 
+    public ScreenResolution getScreenResolution() {
+        return screenResolution;
+    }
+
     /**
      * The type of browser to be used. Chrome, Opera, Safari, etc.
      * <p>
@@ -97,6 +105,10 @@ public class DesiredCapabilitiesConfigurationProperties {
      */
     public void setRunType(RunType runType) {
         this.runType = runType;
+    }
+
+    public void setScreenResolution(ScreenResolution screenResolution) {
+        this.screenResolution = screenResolution;
     }
 
     /**

--- a/framework/src/main/java/io/github/kgress/scaffold/util/AutomationWait.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/util/AutomationWait.java
@@ -17,7 +17,7 @@ import java.util.Map;
 @Slf4j
 public class AutomationWait {
 
-    private final static Long TEN_SECONDS = 10L;
+    private final static Long FIVE_SECONDS = 5L;
     private final WebDriverWrapper driver;
 
     // Custom timeout the developer can set if they wish to override the default timeout of 60 seconds on a
@@ -103,7 +103,7 @@ public class AutomationWait {
                 customTimeout = null;
             } else {
                 // If we get here, then use our default timeout
-                returnTimeout = TEN_SECONDS;
+                returnTimeout = FIVE_SECONDS;
             }
         }
         return returnTimeout;

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/ScaffoldBaseTest.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/ScaffoldBaseTest.java
@@ -1,8 +1,11 @@
 package io.github.kgress.scaffold.webdriver;
 
 import io.github.kgress.scaffold.environment.config.DesiredCapabilitiesConfigurationProperties;
+import io.github.kgress.scaffold.webdriver.interfaces.TestContextSetting;
+import io.github.kgress.scaffold.webelements.WebElementWait;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.openqa.selenium.WebDriver;
@@ -82,6 +85,17 @@ public class ScaffoldBaseTest {
      */
     protected WebDriverWrapper getWebDriverWrapper() {
         return getWebDriverContext().getWebDriverManager().getWebDriverWrapper();
+    }
+
+    /**
+     * Enabled explicit waits on the thread. This feature will automatically perform a {@link WebElementWait#waitUntilDisplayed()}
+     * any instantiated strong typed element.
+     *
+     * To properly enable this, add it to your own projects {@link BeforeAll} method. This method must be static to respect
+     * the requirements of JUNIT.
+     */
+    protected static void enableExplicitWaits() {
+        TestContext.baseContext().addSetting(TestContextSetting.WAIT_FOR_DISPLAY_ENABLED, true);
     }
 
     /**

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/AbstractClickable.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/AbstractClickable.java
@@ -17,6 +17,10 @@ public abstract class AbstractClickable extends AbstractWebElement {
     private boolean popupsExpected = false;
     protected DisplayWaitCondition waitCondition;
 
+    public AbstractClickable(String cssSelector) {
+        super(cssSelector);
+    }
+
     public AbstractClickable(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/AbstractWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/AbstractWebElement.java
@@ -39,6 +39,11 @@ public abstract class AbstractWebElement implements BaseWebElement {
     protected WebElement baseElement;
     private WebElementWait webElementWait;
 
+    public AbstractWebElement(String cssSelector) {
+        this.setBy(By.cssSelector(cssSelector));
+        initWait();
+    }
+
     /**
      * Create a new element, using the supplied By locator. This does not call or invoke WebDriver in any way--it merely stores the locator for later use
      *
@@ -202,6 +207,11 @@ public abstract class AbstractWebElement implements BaseWebElement {
     }
 
     @Override
+    public <T extends AbstractWebElement> T findElement(Class<T> elementClass, String cssSelector) {
+        return findElement(elementClass, By.cssSelector(cssSelector));
+    }
+
+    @Override
     // TODO this is duplicate from WebDriverWrapper. Can we just provide the wrapper instead of re-writing? Or, should
     //   we move finding elements to this class?
     public <T extends AbstractWebElement> List<T> findElements(Class<T> elementClass, By by) {
@@ -225,6 +235,11 @@ public abstract class AbstractWebElement implements BaseWebElement {
             }
         }
         return newElements;
+    }
+
+    @Override
+    public <T extends AbstractWebElement> List<T> findElements(Class<T> elementClass, String cssSelector) {
+        return findElements(elementClass, By.cssSelector(cssSelector));
     }
 
     @Override

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/ButtonWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/ButtonWebElement.java
@@ -8,6 +8,10 @@ import org.openqa.selenium.WebElement;
  */
 public class ButtonWebElement extends AbstractClickable {
 
+    public ButtonWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public ButtonWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/CheckBoxWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/CheckBoxWebElement.java
@@ -8,6 +8,10 @@ import org.openqa.selenium.WebElement;
  */
 public class CheckBoxWebElement extends AbstractClickable {
 
+    public CheckBoxWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public CheckBoxWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/DateWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/DateWebElement.java
@@ -24,6 +24,10 @@ public class DateWebElement extends AbstractWebElement {
     // Local DateFormat which will override the global DateFormat
     private DateFormat localDateFormat;
 
+    public DateWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public DateWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/DivWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/DivWebElement.java
@@ -19,6 +19,10 @@ public class DivWebElement extends AbstractClickable {
         super(by);
     }
 
+    public DivWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public DivWebElement(By by, By parentBy) {
         super(by, parentBy);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/DropDownWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/DropDownWebElement.java
@@ -10,10 +10,14 @@ import java.util.stream.Collectors;
 /**
  * A strongly typed representation of a DropDown {@link WebElement}.
  */
-public class DropDownWebElement extends AbstractWebElement {
+public class DropDownWebElement extends AbstractClickable {
 
     public DropDownWebElement(By by) {
         super(by);
+    }
+
+    public DropDownWebElement(String cssSelector) {
+        super(cssSelector);
     }
 
     public DropDownWebElement(By by, By parentBy) {

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/ImageWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/ImageWebElement.java
@@ -12,6 +12,10 @@ public class ImageWebElement extends AbstractWebElement {
         super(by, parentElement);
     }
 
+    public ImageWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public ImageWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/InputWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/InputWebElement.java
@@ -8,6 +8,10 @@ import org.openqa.selenium.WebElement;
  */
 public class InputWebElement extends AbstractClickable {
 
+    public InputWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public InputWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/LinkWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/LinkWebElement.java
@@ -8,6 +8,10 @@ import org.openqa.selenium.WebElement;
  */
 public class LinkWebElement extends AbstractClickable {
 
+    public LinkWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public LinkWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/RadioWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/RadioWebElement.java
@@ -11,6 +11,10 @@ import org.openqa.selenium.WebElement;
  */
 public class RadioWebElement extends AbstractClickable {
 
+    public RadioWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public RadioWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/StaticTextWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/StaticTextWebElement.java
@@ -12,6 +12,10 @@ import org.openqa.selenium.WebElement;
  */
 public class StaticTextWebElement extends AbstractClickable {
 
+    public StaticTextWebElement(String cssSelector) {
+        super(cssSelector);
+    }
+
     public StaticTextWebElement(By by) {
         super(by);
     }

--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/interfaces/BaseWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/interfaces/BaseWebElement.java
@@ -80,6 +80,16 @@ public interface BaseWebElement {
     <T extends AbstractWebElement> T findElement(Class<T> elementClass, By by);
 
     /**
+     * Performs the same find details by {@link #findElement(Class, By)} but with a css selector.
+     *
+     * @param elementClass the class of the element that is being found
+     * @param cssSelector the css selector of the element
+     * @param <T> the Type Reference that extends off of {@link AbstractWebElement}
+     * @return the element as the specified Type Reference {@link AbstractWebElement}
+     */
+    <T extends AbstractWebElement> T findElement(Class<T> elementClass, String cssSelector);
+
+    /**
      * Finds a list of elements of the given class, using the current webelement as the "anchor" point. Similar to the Selenium webelement.findElements() method,
      * this allows you to ask for a {@literal List<LinkWebElement>} or {@literal List<ButtonWebElement>} based on the same criteria.
      *
@@ -92,6 +102,16 @@ public interface BaseWebElement {
      * @return the list of elements as the specified Type Reference {@link AbstractWebElement}
      */
     <T extends AbstractWebElement> List<T> findElements(Class<T> elementClass, By by);
+
+    /**
+     * Performs the same find detailed by {@link #findElements(Class, By)} but with a css selector
+     *
+     * @param elementClass the class of the element that is being found
+     * @param cssSelector the css selector of the element
+     * @param <T> the type reference that extends {@link AbstractWebElement}
+     * @return the list of elements as the specified Type Reference {@link AbstractWebElement}
+     */
+    <T extends AbstractWebElement> List<T> findElements(Class<T> elementClass, String cssSelector);
 
     /**
      * Indicates whether or not the element is displayed.

--- a/framework/src/test/java/io/github/kgress/scaffold/BaseUnitTest.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/BaseUnitTest.java
@@ -118,9 +118,13 @@ public abstract class BaseUnitTest {
     /**
      * A nested class for testing against abstract elements
      */
-    public class TestableAbstractWebElement extends AbstractWebElement {
+    public static class TestableAbstractWebElement extends AbstractWebElement {
         public TestableAbstractWebElement() {
             this(null, (By) null); //have to cast the second null arg to disambiguate the parentBy from the parentElement
+        }
+
+        public TestableAbstractWebElement(String cssSelector) {
+            super(cssSelector);
         }
 
         public TestableAbstractWebElement(By by, By parentBy) {

--- a/framework/src/test/java/io/github/kgress/scaffold/webdrivercontext/ExplicitWaitTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webdrivercontext/ExplicitWaitTests.java
@@ -1,0 +1,23 @@
+package io.github.kgress.scaffold.webdrivercontext;
+
+import io.github.kgress.scaffold.BaseUnitTest;
+import io.github.kgress.scaffold.webdriver.TestContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static io.github.kgress.scaffold.webdriver.interfaces.TestContextSetting.WAIT_FOR_DISPLAY_ENABLED;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExplicitWaitTests extends BaseUnitTest {
+
+    @Before
+    public void enableExplicitWaits() {
+        TestContext.baseContext().addSetting(WAIT_FOR_DISPLAY_ENABLED, true);
+    }
+
+    @Test
+    public void testEnableExplicitWaits() {
+        var explicitWaitEnabled = TestContext.baseContext().getSetting(Boolean.class, WAIT_FOR_DISPLAY_ENABLED);
+        assertTrue(explicitWaitEnabled);
+    }
+}

--- a/framework/src/test/java/io/github/kgress/scaffold/webdriverwrapper/WebDriverWrapperTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webdriverwrapper/WebDriverWrapperTests.java
@@ -11,8 +11,7 @@ import org.openqa.selenium.WebElement;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WebDriverWrapperTests extends BaseUnitTest {
 
@@ -47,5 +46,16 @@ public class WebDriverWrapperTests extends BaseUnitTest {
     @Test
     public void testFindElementDoesntExist() {
         assertThrows(NoSuchElementException.class, () -> mockWebDriver.findElement(By.id("elementDoesNotExist")));
+    }
+
+    @Test
+    public void testSetSeleniumTimeout() {
+        var newTimeout = 10L;
+        var existingTimeout = webDriverWrapper.getSeleniumObjectTimeout();
+        var actualExistingTimeout = 15L; //The value set in WebDriverWrapper
+
+        assertEquals(actualExistingTimeout, existingTimeout);
+        webDriverWrapper.setSeleniumObjectTimeout(newTimeout);
+        assertEquals(newTimeout, webDriverWrapper.getSeleniumObjectTimeout());
     }
 }

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/AbstractWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/AbstractWebElementTests.java
@@ -5,6 +5,7 @@ import io.github.kgress.scaffold.models.unittests.MockLogs;
 import io.github.kgress.scaffold.models.unittests.MockWebDriver;
 import io.github.kgress.scaffold.models.unittests.MockWebElement;
 import io.github.kgress.scaffold.util.AutomationUtils;
+import io.github.kgress.scaffold.webelements.AbstractWebElement;
 import io.github.kgress.scaffold.webelements.DivWebElement;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
@@ -16,11 +17,7 @@ import org.openqa.selenium.logging.LogType;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.springframework.test.util.AssertionErrors.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AbstractWebElementTests extends BaseUnitTest {
 
@@ -99,47 +96,47 @@ public class AbstractWebElementTests extends BaseUnitTest {
     public void testIsEnabled() {
         var testElement = new TestableAbstractWebElement(mockElement1);
 
-        assertTrue("The element should be enabled by default", testElement.isEnabled());
+        assertTrue(testElement.isEnabled(), "The element should be enabled by default");
         mockElement1.setEnabled(false);
-        assertFalse("The element should no longer be enabled", testElement.isEnabled());
+        assertFalse(testElement.isEnabled(), "The element should no longer be enabled");
     }
 
     @Test
     public void testIsDisplayed() {
         var testElement = new TestableAbstractWebElement(mockElement1);
 
-        assertTrue("The element should be displayed by default", testElement.isDisplayed());
+        assertTrue(testElement.isDisplayed(), "The element should be displayed by default");
         mockElement1.setIsDisplayed(false);
-        assertFalse("The element should no longer be displayed", testElement.isDisplayed());
+        assertFalse(testElement.isDisplayed(), "The element should no longer be displayed");
     }
 
     @Test
     public void testGetSize() {
         testAbstractWebElement.setBaseElement(mockElement1);
-        assertNull("getSize() should return null", testAbstractWebElement.getSize());
+        assertNull(testAbstractWebElement.getSize(), "getSize() should return null");
     }
 
     @Test
     public void testGetLocation() {
         testAbstractWebElement.setBaseElement(mockElement1);
-        assertNull("getLocation() should return null", testAbstractWebElement.getLocation());
+        assertNull(testAbstractWebElement.getLocation(), "getLocation() should return null");
     }
 
     @Test
     public void testGetCssValue() {
         testAbstractWebElement.setBaseElement(mockElement1);
-        assertNull("getCssValue() should return null", testAbstractWebElement.getCssValue("something"));
+        assertNull(testAbstractWebElement.getCssValue("something"), "getCssValue() should return null");
     }
 
     @Test
     public void testExists() {
         var testElement = new TestableAbstractWebElement(mockElement1);
-        assertTrue("The element should exist", testElement.exists());
+        assertTrue(testElement.exists(), "The element should exist");
     }
 
     @Test
     public void testExistsFalse() {
-        assertFalse("The element should not exist", testAbstractWebElement.exists());
+        assertFalse(testAbstractWebElement.exists(), "The element should not exist");
     }
 
     /**
@@ -170,7 +167,7 @@ public class AbstractWebElementTests extends BaseUnitTest {
     @Test
     public void testToStringByAndByConstructor() {
         //The constructor that takes By locators for both the primary element and the parent element
-        var byElementByParent = new TestableAbstractWebElement(By.id( "baz"), By.xpath("//ew/xpath"));
+        var byElementByParent = new TestableAbstractWebElement(By.id("baz"), By.xpath("//ew/xpath"));
         assertEquals("Parent By: [By.xpath: //ew/xpath], By: [By.id: baz]", byElementByParent.toString(),
                 "The element's toString should be correct: 'By, parentBy' constructor");
     }
@@ -178,7 +175,7 @@ public class AbstractWebElementTests extends BaseUnitTest {
     @Test
     public void testToStringByAndWebElementConstructor() {
         //The constructor that takes a By locator for the main element, and a webelement for the parent
-        var byElementWebElementParent = new TestableAbstractWebElement( By.id( "baz"), new MockWebElement() );
+        var byElementWebElementParent = new TestableAbstractWebElement(By.id("baz"), new MockWebElement());
         assertEquals("Parent webelement: [MockWebElement: I Mock Thee!], By: [By.id: baz]", byElementWebElementParent.toString(),
                 "The element's toString should be correct: 'By, parent element' constructor");
     }
@@ -196,5 +193,38 @@ public class AbstractWebElementTests extends BaseUnitTest {
         //Test the null, null constructor (should never happen in real life, but you never know...)
         assertEquals("This element was not properly initialized with a By locator or a base element. Please check your code", testAbstractWebElement.toString(),
                 "The element's toString should be correct: 'null, null' constructor");
+    }
+
+    /**
+     * Test to ensure that we can find elements with the {@link AbstractWebElement#findElement(Class, String)}
+     * method. This method specifically finds an element with a CSS Selector.
+     */
+    @Test
+    public void testFindElementWithCSS() {
+        var sampleText = "Sample Text";
+        var abstractWebElement = new TestableAbstractWebElement("testSelector");
+        var testWebElement = new MockWebElement();
+        testWebElement.setText(sampleText);
+        mockWebDriver.setElementToFind(testWebElement);
+
+        var testDivWebElement = abstractWebElement.findElement(DivWebElement.class, ".testSelector");
+        assertTrue(testDivWebElement.getText().contains(sampleText));
+    }
+
+    @Test
+    public void testFindElementsWithCSS() {
+        var abstractWebElement = new TestableAbstractWebElement("testSelector");
+        var testElement1 = new MockWebElement().text(TEXT_NAME_1);
+        var testElement2 = new MockWebElement().text(TEXT_NAME_2);
+
+        var elementList = new ArrayList<WebElement>();
+        elementList.add(testElement1);
+        elementList.add(testElement2);
+        mockWebDriver.setElementsToFind(elementList);
+
+        var testDivWebElements = abstractWebElement.findElements(DivWebElement.class, ".testSelector");
+        assertEquals(2, testDivWebElements.size());
+        assertTrue(testDivWebElements.get(0).getText().contains(TEXT_NAME_1));
+        assertTrue(testDivWebElements.get(1).getText().contains(TEXT_NAME_2));
     }
 }

--- a/models/src/main/java/io/github/kgress/scaffold/models/enums/ScreenResolution.java
+++ b/models/src/main/java/io/github/kgress/scaffold/models/enums/ScreenResolution.java
@@ -1,0 +1,60 @@
+package io.github.kgress.scaffold.models.enums;
+
+/**
+ * This enum provides screen resolution choices that are most commonly accepted by browser. This is not an all inclusive
+ * list and additional resolutions can be added later to support other devices.
+ */
+public enum ScreenResolution {
+
+    SIZE_800x600(800, 600),
+    SIZE_1024x1080(1024, 1080),
+    SIZE_1152x864(1152, 864),
+    SIZE_1280x960(1280, 960),
+    SIZE_1376x1032(1376, 1032),
+    SIZE_1600x1200(1600, 1200),
+    SIZE_1920x1440(1920, 1440),
+    SIZE_2048x1536(2048, 1536);
+
+    private final int width;
+    private final int height;
+
+    ScreenResolution(int width, int height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    public int getWidth() {
+        return width;
+    }
+
+    public int getHeight() {
+        return height;
+    }
+
+    public String getScreenShotResolutionAsString(ScreenResolutionType resolutionType) {
+        var widthAsString = String.valueOf(getWidth());
+        var heightAsString = String.valueOf(getHeight());
+        return String.format(resolutionType.getStringFormat(), widthAsString, heightAsString);
+    }
+
+    public enum ScreenResolutionType {
+        SELENIUM("selenium", "%s,%s"),
+        SAUCELABS("sauce", "%sx%s");
+
+        private final String resolutionType;
+        private final String stringFormat;
+
+        ScreenResolutionType(String resolutionType, String stringFormat) {
+            this.resolutionType = resolutionType;
+            this.stringFormat = stringFormat;
+        }
+
+        public String getResolutionType() {
+            return resolutionType;
+        }
+
+        public String getStringFormat() {
+            return stringFormat;
+        }
+    }
+}


### PR DESCRIPTION
PR for #35 

* Added screen size as a desired capability. Also configured the proper screen size handling required by Scaffold in order to change screen size for their vm's.
* Lowered the explicit wait timeout by 50%. 10 seconds was just too much. 
* Added a helper method to `ScaffoldBaseTest` that allows users to enable explicit waits without having to type ```TestContext.baseContext().addSetting(TestContextSetting.WAIT_FOR_DISPLAY_ENABLED, true)```
* Added a new constructor for `AbstractWebElement` and all child classes that takes a css selector as a parameter. Makes code look a little better.
* Added new `findElement` and `findElements` methods on `AbstractWebElement` that takes a css selector as a parameter. Another QOL update that makes code look a little better.
