### PR TITLE
fix: Removing extra declaration of selenium-java

### DIFF
--- a/models/pom.xml
+++ b/models/pom.xml
@@ -28,11 +28,6 @@
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-java</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-support</artifactId>
         </dependency>
 


### PR DESCRIPTION
I was getting a warning from Maven, and I think this will fix it.