### PR TITLE
feat: Add parentTunnel capability for Sauce connections

### DIFF
--- a/environment/src/main/java/io/github/kgress/scaffold/environment/config/DesiredCapabilitiesConfigurationProperties.java
+++ b/environment/src/main/java/io/github/kgress/scaffold/environment/config/DesiredCapabilitiesConfigurationProperties.java
@@ -145,6 +145,7 @@ public class DesiredCapabilitiesConfigurationProperties {
         private String password;
         private String accessKey;
         private String tunnelIdentifier;
+        private String parentTunnel;
 
         public String getUrl() {
             return url;
@@ -165,6 +166,8 @@ public class DesiredCapabilitiesConfigurationProperties {
         public String getTunnelIdentifier() {
             return tunnelIdentifier;
         }
+
+        public String getParentTunnel() { return parentTunnel; }
 
         /**
          * The main sauce URL to be used. In the event this ever changes, we'll let the implementing project handle
@@ -203,6 +206,13 @@ public class DesiredCapabilitiesConfigurationProperties {
          */
         public void setTunnelIdentifier(String tunnelIdentifier) {
             this.tunnelIdentifier = tunnelIdentifier;
+        }
+
+        /**
+         * The name of the user that owns tunnel that is being used to allow sauce labs to connect to your lower environments.
+         */
+        public void setParentTunnel(String parentTunnel) {
+            this.parentTunnel = parentTunnel;
         }
     }
 }

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/WebDriverManager.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/WebDriverManager.java
@@ -491,10 +491,14 @@ public class WebDriverManager {
         var accessKey = sauce.getAccessKey();
         var sauceUrl = "@ondemand.saucelabs.com/wd/hub";
         var tunnelIdentifier = sauce.getTunnelIdentifier();
+        var parentTunnel = sauce.getParentTunnel();
 
         try {
             if (sauce.getTunnelIdentifier() != null) {
                 browserOptions.setCapability("tunnelIdentifier", tunnelIdentifier);
+            }
+            if (sauce.getParentTunnel() != null) {
+                browserOptions.setCapability("parentTunnel", parentTunnel);
             }
             browserOptions.setCapability("name", testName);
             if (remoteUrl == null) {


### PR DESCRIPTION
PR for [#56](https://github.com/kgress/scaffold/issues/56).  Adds the parentTunnel to the `SauceContext` and sets the capability in the `WebDriverManager`.