### PR TITLE
fix: removed check for capability on getting screenshot from Screensh…

### DIFF
--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/ScreenshotRemoteDriver.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/ScreenshotRemoteDriver.java
@@ -29,9 +29,6 @@ public class ScreenshotRemoteDriver extends RemoteWebDriver implements TakesScre
      */
     @Override
     public <X> X getScreenshotAs(OutputType<X> target) throws WebDriverException {
-        if ((Boolean) getCapabilities().getCapability(CapabilityType.TAKES_SCREENSHOT)) {
-            return target.convertFromBase64Png(execute(DriverCommand.SCREENSHOT).getValue().toString());
-        }
-        return null;
+        return target.convertFromBase64Png(execute(DriverCommand.SCREENSHOT).getValue().toString());
     }
 }


### PR DESCRIPTION
PR for #53 . Comment from the issue: I personally think we can remove the check for the desired capability TAKES_SCREENSHOT in this context. If a user wants to get the screenshot from the driver, they are going to be calling this method explicitly.

It would make sense, imo, if Scaffold was automatically providing a screen shot helper for failed testing. Since the current implementation doesn't have this, I think we're safe with removing the check.