### PR TITLE
catch UnsupportedCommandException

### DIFF
--- a/framework/src/main/java/io/github/kgress/scaffold/webelements/AbstractWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webelements/AbstractWebElement.java
@@ -346,6 +346,8 @@ public abstract class AbstractWebElement implements BaseWebElement {
                         log.info(new Date(entry.getTimestamp()) + " " + entry.getLevel() + " " + entry.getMessage());
                     }
                 }
+            } catch (UnsupportedCommandException n) {
+                log.debug("Logging not supported for the supplied browser.");
             } catch (NullPointerException n) {
                 log.debug("No Errors reported in Console Logs during failure.");
             }


### PR DESCRIPTION
firefox throws UnsupportedCommandException when using any logging feature
fixes #72