### PR TITLE
feat: Add timeZone to Sauce configuration options #75

### DIFF
--- a/environment/src/main/java/io/github/kgress/scaffold/environment/config/DesiredCapabilitiesConfigurationProperties.java
+++ b/environment/src/main/java/io/github/kgress/scaffold/environment/config/DesiredCapabilitiesConfigurationProperties.java
@@ -146,6 +146,7 @@ public class DesiredCapabilitiesConfigurationProperties {
         private String accessKey;
         private String tunnelIdentifier;
         private String parentTunnel;
+        private String timeZone;
 
         public String getUrl() {
             return url;
@@ -168,6 +169,8 @@ public class DesiredCapabilitiesConfigurationProperties {
         }
 
         public String getParentTunnel() { return parentTunnel; }
+
+        public String getTimeZone() { return timeZone; }
 
         /**
          * The main sauce URL to be used. In the event this ever changes, we'll let the implementing project handle
@@ -213,6 +216,13 @@ public class DesiredCapabilitiesConfigurationProperties {
          */
         public void setParentTunnel(String parentTunnel) {
             this.parentTunnel = parentTunnel;
+        }
+
+        /**
+         * The custom time zone to use when spinning up the sauce lab VM.
+         */
+        public void setTimeZone(String timeZone) {
+            this.timeZone = timeZone;
         }
     }
 }

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/WebDriverManager.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/WebDriverManager.java
@@ -508,6 +508,7 @@ public class WebDriverManager {
         var defaultSauceUrl = "@ondemand.saucelabs.com/wd/hub";
         var tunnelIdentifier = sauce.getTunnelIdentifier();
         var parentTunnel = sauce.getParentTunnel();
+        var timeZone = sauce.getTimeZone();
         var sauceCaps = new MutableCapabilities();
         var sauceConfigUrl = sauce.getUrl();
 
@@ -520,6 +521,9 @@ public class WebDriverManager {
             }
             if (sauceConfigUrl == null) {
                 sauceConfigUrl = URI.create("https://" + username + ":" + accessKey + defaultSauceUrl).toString();
+            }
+            if (sauce.getTimeZone() != null) {
+                sauceCaps.setCapability("timeZone", timeZone);
             }
 
             sauceCaps.setCapability("username", username);


### PR DESCRIPTION
PR for #75. Adds the timeZone to the SauceContext and sets the capability in the WebDriverManager.

