### PR TITLE
feat: isOnPage() does not contain logic to fail test when result is f…

### DIFF
--- a/framework/pom.xml
+++ b/framework/pom.xml
@@ -137,6 +137,23 @@
             <groupId>com.saucelabs</groupId>
             <artifactId>saucerest</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+        </dependency>
     </dependencies>
 
     <scm>

--- a/framework/src/main/java/io/github/kgress/scaffold/util/AutomationWait.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/util/AutomationWait.java
@@ -1,7 +1,9 @@
 package io.github.kgress.scaffold.util;
 
 import io.github.kgress.scaffold.exception.AutomationWaitException;
+import io.github.kgress.scaffold.webdriver.BasePage;
 import io.github.kgress.scaffold.webdriver.WebDriverWrapper;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.support.ui.ExpectedCondition;
@@ -15,6 +17,7 @@ import java.util.Map;
  * via WebDriver's built-in wait mechanism.
  */
 @Slf4j
+@Getter
 public class AutomationWait {
 
     private final static Long FIVE_SECONDS = 5L;
@@ -82,6 +85,22 @@ public class AutomationWait {
     }
 
     /**
+     * A custom wait condition to wait until the page's DOM has switched to the complete status. Useful for page navigation
+     * to wait on returning a new page object until the DOM is loaded.
+     *
+     * This is already called in {@link BasePage} isOnPage to allow users verification of the web page they've navigated to.
+     * It is unnecessary to call this again after a page has loaded. However, this might come in handy when interactions
+     * on your web page change the state of the dom.
+     *
+     * @return as {@link Boolean}
+     */
+    public Boolean waitUntilPageIsLoaded() {
+        var domReadyStateScript = "return document.readyState";
+        return waitForCustomCondition(
+                page -> getDriver().getJavascriptExecutor().executeScript(domReadyStateScript).equals("complete"));
+    }
+
+    /**
      * Returns the set timeout in seconds.
      *
      * @return the timeout as a {@link Long} in seconds.
@@ -122,4 +141,3 @@ public class AutomationWait {
         return waits.get(timeOutToUse);
     }
 }
-

--- a/framework/src/main/java/io/github/kgress/scaffold/webdriver/BasePage.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/webdriver/BasePage.java
@@ -1,14 +1,20 @@
 package io.github.kgress.scaffold.webdriver;
 
+import io.github.kgress.scaffold.util.AutomationWait;
+import io.github.kgress.scaffold.webelements.AbstractWebElement;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.interactions.Actions;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 /**
  * The purpose of this object is to provide a set of common functionality that can be shared across page objects in
  * an implementing project.
  *
  * A common use case for all pages is a form of verification that the page is correct when navigated to. For now, the inclusion
- * of {@link #isOnPage()} will be used. As we continue development, we can continue to add functionality here.
+ * of {@link #verifyIsOnPage(AbstractWebElement...)} will be used. As we continue development, we can continue to add functionality here.
  *
  * Note: We should also be very protective about page objects *not* having access to the web driver. The page object, by
  * design, should be agnostic to any relationship with the web driver and only have the knowledge of our strongly typed
@@ -18,12 +24,72 @@ import org.openqa.selenium.interactions.Actions;
 public abstract class BasePage {
 
     /**
+     * {@link Deprecated} in favor of {@link #verifyIsOnPage(AbstractWebElement...)}. This method will be phased out in the next
+     * breaking release.
+     *
      * A method to be overridden by the implementing project. Typically, it's best to use elements that are unique to
      * the page object that is being navigated to.
      *
      * @return the {@link Boolean} value to determine if the page is correctly loaded
      */
+    @Deprecated
     public abstract boolean isOnPage();
+
+    /**
+     * A method that is used to verify a number of elements are displayed on the page when navigating to it. In addition,
+     * it will check to ensure the DOM is in a ready and loaded state prior to proceeding. This will help alleviate
+     * issues with websites where it takes additional time to load the page due to extraneous db calls or slow loading JS.
+     *
+     * It's best to use this method in the constructor of the page object as it will be invoked at the time the page is
+     * instantiated. For example:
+     *
+     * <pre>{@code
+     * @Getter
+     * public class LoginPage() {
+     *     private InputWebElement emailInput = new InputWebElement("#email");
+     *     private InputWebElement passwordInput = new InputWebElement("#password");
+     *
+     *     public LoginPage() {
+     *         isOnPage(getEmailInput, getPasswordInput);
+     *     }
+     * }
+     * }</pre>
+     *
+     * The elements passed in to this method will be checked by selenium to see if they are displayed. Make sure to pass in
+     * elements that are unique to the page that won't show up on other pages. For example, a login page will have an email
+     * and password input and would pass in those elements as parameters. Don't use elements from headers or a logo that
+     * might appear on all of the pages.
+     *
+     * @param element the element(s) that will be checked if displayed
+     * @return the {@link Boolean} value to determine if the page is correctly loaded
+     */
+    public Boolean verifyIsOnPage(AbstractWebElement... element) {
+        // Get the list of elements and iterate over them so we can remove any duplicates
+        var listOfElements = Arrays.stream(element)
+                .distinct() //removes duplicates
+                .collect(Collectors.toList());
+
+        // Check to make sure the list isn't empty, just in case. We need to at least have one element so we can verify
+        // it's displayed
+        if (listOfElements.isEmpty()) {
+            throw new RuntimeException(String.format("No elements to search for when verifying %s. " +
+                    "Please provide at least one element to check it is displayed.", getClass().getSimpleName()));
+        }
+
+        // The wait condition should wait for the page to load into the complete state. When complete, check to make
+        // sure the elements are displayed. However, if it doesn't (for example, if there's a time out), throw an exception.
+        var isPageLoaded = getAutomationWait().waitUntilPageIsLoaded();
+        if (isPageLoaded) {
+            listOfElements.forEach(elementOnPage -> {
+                var isDisplayed = elementOnPage.isDisplayed();
+                if (!isDisplayed) {
+                    throw new NoSuchElementException(String.format("Page verification failed. Could not find the element %s for " +
+                            "the intended page: %s", elementOnPage.toString(), getClass().getSimpleName()));
+                }
+            });
+        }
+        return true;
+    }
 
     /**
      * Gets the Selenium based {@link Actions} object for the current thread. This is currently not strongly typed and
@@ -44,6 +110,14 @@ public abstract class BasePage {
      */
     protected JavascriptExecutor getJavascriptExecutor() {
         return getWebDriverWrapper().getJavascriptExecutor();
+    }
+
+    /**
+     * Gets the {@link AutomationWait} from the current thread's {@link WebDriverWrapper}
+     * @return as {@link AutomationWait}
+     */
+    protected AutomationWait getAutomationWait() {
+        return getWebDriverWrapper().getAutomationWait();
     }
 
     /**

--- a/framework/src/test/java/io/github/kgress/scaffold/page/BasePageTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/page/BasePageTests.java
@@ -1,0 +1,76 @@
+package io.github.kgress.scaffold.page;
+
+import io.github.kgress.scaffold.BaseUnitTest;
+import io.github.kgress.scaffold.util.AutomationWait;
+import io.github.kgress.scaffold.webdriver.BasePage;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.openqa.selenium.NoSuchElementException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+public class BasePageTests extends BaseUnitTest {
+
+    private BasePage testBasePage = new BasicBasePage();
+    private AutomationWait mockAutomationWait = Mockito.mock(AutomationWait.class);
+
+    @Test
+    public void isOnPage_noVarArgsTest() {
+        assertThrows(RuntimeException.class, testBasePage::verifyIsOnPage);
+    }
+
+    @Test
+    public void isOnPage_elementDisplayed() {
+        when(mockAutomationWait.waitUntilPageIsLoaded()).thenReturn(true);
+        var testElement = new TestableAbstractWebElement(mockElement1);
+        var isOnPage = testBasePage.verifyIsOnPage(testElement);
+        assertTrue(isOnPage);
+    }
+
+    @Test
+    public void isOnPage_elementsDisplayed() {
+        when(mockAutomationWait.waitUntilPageIsLoaded()).thenReturn(true);
+        var testElement = new TestableAbstractWebElement(mockElement1);
+        var testElement2 = new TestableAbstractWebElement(mockElement2);
+        var isOnPage = testBasePage.verifyIsOnPage(testElement, testElement2);
+        assertTrue(isOnPage);
+    }
+
+    @Test
+    public void isOnPage_elementNotDisplayed() {
+        when(mockAutomationWait.waitUntilPageIsLoaded()).thenReturn(true);
+        var testElement = new TestableAbstractWebElement(mockElement1);
+        mockElement1.setIsDisplayed(false);
+        assertThrows(NoSuchElementException.class, () -> testBasePage.verifyIsOnPage(testElement));
+    }
+
+    @Test
+    public void isOnPage_elementsNotDisplayed() {
+        when(mockAutomationWait.waitUntilPageIsLoaded()).thenReturn(true);
+        var testElement = new TestableAbstractWebElement(mockElement1);
+        var testElement2 = new TestableAbstractWebElement(mockElement2);
+        mockElement1.setIsDisplayed(false);
+        mockElement2.setIsDisplayed(false);
+        assertThrows(NoSuchElementException.class, () -> testBasePage.verifyIsOnPage(testElement, testElement2));
+    }
+    
+    /**
+     * This nested class is only intended for unit testing purposes. It should never be used for production code. We
+     * required a mocked automation wait in order to properly set the {@link AutomationWait#waitUntilPageIsLoaded()}
+     * condition.
+     */
+    private class BasicBasePage extends BasePage {
+
+        @Override
+        public boolean isOnPage() {
+            return false;
+        }
+
+        @Override
+        public AutomationWait getAutomationWait() {
+            return mockAutomationWait;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
         <org.selenium-java.version>3.141.59</org.selenium-java.version>
         <com.saucelabs.sauce-junit.version>2.1.25</com.saucelabs.sauce-junit.version>
         <com.saucelabs.saucerest.version>1.0.44</com.saucelabs.saucerest.version>
+        <org.mockito.version>3.6.0</org.mockito.version>
+        <net.byte-buddy.version>1.10.18</net.byte-buddy.version>
 
         <!--Plugins-->
         <org.apache.maven.plugins.maven-compiler-plugin.veresion>3.8.1</org.apache.maven.plugins.maven-compiler-plugin.veresion>
@@ -302,6 +304,27 @@
                 <groupId>com.saucelabs</groupId>
                 <artifactId>saucerest</artifactId>
                 <version>${com.saucelabs.saucerest.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>${org.mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-junit-jupiter</artifactId>
+                <version>${org.mockito.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <!--This byte buddy version is required in order to resolve an issue with instantiation of mocked classes in Mockito-->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${net.byte-buddy.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
**Summary**
This PR updates the `BasePage` with a new method, `verifyIsOnPage(AbstractWebElement... element)`. This new method will wait for the DOM ready state to be complete, check for elements on the page to be displayed, and then return a Boolean status of `true` if it successfully loaded and found the elements.

**Changes**
* `isOnPage()` has been deprecated on `BasePage` and will be cycled out in a later undetermined release.
* `verifyIsOnPage(AbstractWebElement... element)` has been added on `BasePage` and will be the new method for checking to ensure the user is on the current page.
* `getAutomationWait()` has been added on `BasePage`. This was necessary in order to provide mocking access to the unit test while also ensuring we do not expose the base driver to page objects.
* `waitUntilLoaded()` has been added on `AutomationWait`. This method will wait for the dom ready state to be complete prior to returning a `Boolean` response.
* Unit tests have been added for `BasePage`.








Closes out #74 