### PR TITLE
fix: re-adding in exception handling + null checks for boolean inspections

### DIFF
--- a/framework/src/main/java/io/github/kgress/scaffold/BaseWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/BaseWebElement.java
@@ -227,7 +227,12 @@ public abstract class BaseWebElement {
      * @return  the result as {@link boolean}.
      */
     public boolean isEnabled() {
-        return getRawWebElement().isEnabled();
+        try{
+            var element = getRawWebElement();
+            return element != null && element.isEnabled();
+        }catch (WebDriverException e){
+            return false;
+        }
     }
 
     /**
@@ -237,7 +242,12 @@ public abstract class BaseWebElement {
      * @return  the result as {@link boolean}.
      */
     public boolean isDisplayed() {
-        return getRawWebElement().isDisplayed();
+        try{
+            var element = getRawWebElement();
+            return element != null && element.isDisplayed();
+        }catch (WebDriverException e){
+            return false;
+        }
     }
 
     /**
@@ -246,7 +256,12 @@ public abstract class BaseWebElement {
      * @return the response as true or false
      */
     public boolean isActive() {
-        return getRawWebElement().getAttribute("class").contains("active");
+        try{
+            var element = getRawWebElement();
+            return element != null && element.getAttribute("class").contains("active");
+        }catch (WebDriverException e){
+            return false;
+        }
     }
 
     /**
@@ -256,7 +271,12 @@ public abstract class BaseWebElement {
      * @return      as true or false
      */
     public boolean hasClass(String text) {
-        return getRawWebElement().getAttribute("class").contains(text);
+        try{
+            var element = getRawWebElement();
+            return element != null && element.getAttribute("class").contains(text);
+        }catch (WebDriverException e){
+            return false;
+        }
     }
 
     /**

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
@@ -355,4 +355,36 @@ public class BaseWebElementTests extends BaseUnitTest {
                 .findElement(MockBaseWebElement.class, SharedTestVariables.CSS_SELECTOR1);
         assertEquals(expectedCombinedBy, foundElement.getBy());
     }
+
+    @Test
+    public void testExceptionHandledIsDisplayed(){
+        setBaseWhen(elementByCssSelector);
+        when(mockRawWebElement.isDisplayed()).thenThrow(TimeoutException.class);
+        assertDoesNotThrow(elementByCssSelector::isDisplayed);
+        assertFalse(elementByCssSelector.isDisplayed());
+    }
+
+    @Test
+    public void testExceptionHandledIsEnabled(){
+        setBaseWhen(elementByCssSelector);
+        when(elementByCssSelector.getRawWebElement()).thenThrow(TimeoutException.class);
+        assertDoesNotThrow(elementByCssSelector::isEnabled);
+        assertFalse(elementByCssSelector.isEnabled());
+    }
+
+    @Test
+    public void testExceptionHandledIsActive(){
+        setBaseWhen(elementByCssSelector);
+        when(elementByCssSelector.getRawWebElement()).thenThrow(TimeoutException.class);
+        assertDoesNotThrow(elementByCssSelector::isActive);
+        assertFalse(elementByCssSelector.isActive());
+    }
+
+    @Test
+    public void testExceptionHandledHasClass(){
+        setBaseWhen(elementByCssSelector);
+        when(elementByCssSelector.getRawWebElement()).thenThrow(TimeoutException.class);
+        assertDoesNotThrow(() -> elementByCssSelector.hasClass("class"));
+        assertFalse(elementByCssSelector.hasClass("class"));
+    }
 }

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
@@ -359,7 +359,7 @@ public class BaseWebElementTests extends BaseUnitTest {
     @Test
     public void testExceptionHandledIsDisplayed(){
         setBaseWhen(elementByCssSelector);
-        when(mockRawWebElement.isDisplayed()).thenThrow(TimeoutException.class);
+        when(mockRawWebElement.isDisplayed()).thenThrow(new TimeoutException());
         assertDoesNotThrow(elementByCssSelector::isDisplayed);
         assertFalse(elementByCssSelector.isDisplayed());
     }
@@ -367,7 +367,7 @@ public class BaseWebElementTests extends BaseUnitTest {
     @Test
     public void testExceptionHandledIsEnabled(){
         setBaseWhen(elementByCssSelector);
-        when(elementByCssSelector.getRawWebElement()).thenThrow(TimeoutException.class);
+        when(elementByCssSelector.getRawWebElement()).thenThrow(new TimeoutException());
         assertDoesNotThrow(elementByCssSelector::isEnabled);
         assertFalse(elementByCssSelector.isEnabled());
     }
@@ -375,7 +375,7 @@ public class BaseWebElementTests extends BaseUnitTest {
     @Test
     public void testExceptionHandledIsActive(){
         setBaseWhen(elementByCssSelector);
-        when(elementByCssSelector.getRawWebElement()).thenThrow(TimeoutException.class);
+        when(elementByCssSelector.getRawWebElement()).thenThrow(new TimeoutException());
         assertDoesNotThrow(elementByCssSelector::isActive);
         assertFalse(elementByCssSelector.isActive());
     }
@@ -383,7 +383,7 @@ public class BaseWebElementTests extends BaseUnitTest {
     @Test
     public void testExceptionHandledHasClass(){
         setBaseWhen(elementByCssSelector);
-        when(elementByCssSelector.getRawWebElement()).thenThrow(TimeoutException.class);
+        when(elementByCssSelector.getRawWebElement()).thenThrow(new TimeoutException());
         assertDoesNotThrow(() -> elementByCssSelector.hasClass("class"));
         assertFalse(elementByCssSelector.hasClass("class"));
     }


### PR DESCRIPTION
This resolves #111 and makes all the boolean inspection methods, `isDisplayed(), isEnabled(), isActive() and hasClass()` return false when their conditions fail or there's some other exception.