### PR TITLE
fix: monterey platform configuration to fix sauce safari issue (#127)

### DIFF
--- a/models/src/main/java/io/github/kgress/scaffold/models/enums/desktop/Platform.java
+++ b/models/src/main/java/io/github/kgress/scaffold/models/enums/desktop/Platform.java
@@ -18,6 +18,7 @@ public enum Platform {
   XP("XP"),
   Vista("VISTA"),
   Mac("MAC"),
+  Monterey("macOS 12"),
   Linux("LINUX"),
   Unix("UNIX");
 


### PR DESCRIPTION
- adds Monterey platform configuration to support mac 12 / safari 15 configuration on saucelabs

closes #127 