### PR TITLE
fix: verifyIsOnPage() should throw for nonexistent elements (#130)

### DIFF
--- a/framework/src/main/java/io/github/kgress/scaffold/BasePage.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/BasePage.java
@@ -66,14 +66,10 @@ public class BasePage extends BaseComponent {
     var isPageLoaded = getAutomationWait().waitUntilPageIsLoaded();
     if (isPageLoaded) {
       listOfElements.forEach(elementOnPage -> {
-        try {
-          if (!elementOnPage.isDisplayed()) {
-            throw new TimeoutException();
-          }
-        } catch (TimeoutException e) {
+        if (!elementOnPage.isDisplayed()) {
           throw new TimeoutException(
-              String.format("Page verification failed. Could not find the element " +
-                  "%s for the intended page: %s", elementOnPage, getClass().getSimpleName()));
+                String.format("Page verification failed. Could not find the element " +
+                    "%s for the intended page: %s", elementOnPage, getClass().getSimpleName()));
         }
       });
     } else {

--- a/framework/src/main/java/io/github/kgress/scaffold/BasePage.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/BasePage.java
@@ -67,7 +67,9 @@ public class BasePage extends BaseComponent {
     if (isPageLoaded) {
       listOfElements.forEach(elementOnPage -> {
         try {
-          elementOnPage.isDisplayed();
+          if (!elementOnPage.isDisplayed()) {
+            throw new TimeoutException();
+          }
         } catch (TimeoutException e) {
           throw new TimeoutException(
               String.format("Page verification failed. Could not find the element " +

--- a/framework/src/test/java/io/github/kgress/scaffold/page/BasePageTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/page/BasePageTests.java
@@ -64,7 +64,7 @@ public class BasePageTests extends BaseUnitTest {
     @Test
     public void verifyIsOnPage_elementNotDisplayed() {
         when(mockAutomationWait.waitUntilPageIsLoaded()).thenReturn(true);
-        when(mockDivWebElement.isDisplayed()).thenThrow(TimeoutException.class);
+        when(mockDivWebElement.isDisplayed()).thenReturn(false);
         var exception = assertThrows(TimeoutException.class, () ->
                 testBasePage.verifyIsOnPage_callProtectedMethod(mockDivWebElement));
         assertTrue(exception.getMessage().contains(EXPECTED_FAILED_TEXT));
@@ -74,7 +74,7 @@ public class BasePageTests extends BaseUnitTest {
     public void verifyIsOnPage_elementsNotDisplayed() {
         when(mockAutomationWait.waitUntilPageIsLoaded()).thenReturn(true);
         when(mockDivWebElement.isDisplayed()).thenReturn(true);
-        when(mockInputWebElement.isDisplayed()).thenThrow(TimeoutException.class);
+        when(mockInputWebElement.isDisplayed()).thenReturn(false);
         var exception = assertThrows(TimeoutException.class, () ->
                 testBasePage.verifyIsOnPage_callProtectedMethod(mockDivWebElement, mockInputWebElement));
         assertTrue(exception.getMessage().contains(EXPECTED_FAILED_TEXT));


### PR DESCRIPTION
- checks return value if isDisplayed() in verifyIsOnPage()
closes #130 