### PR TITLE
fix: findElements returns the first child for every child available instead of distinct instances of all children

### DIFF
--- a/framework/src/main/java/io/github/kgress/scaffold/BaseComponent.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/BaseComponent.java
@@ -209,18 +209,11 @@ public class BaseComponent {
    *                       {@link BaseWebElement}
    * @return as a new list of components that extend {@link BaseComponent}
    */
+
   protected <T extends BaseComponent, X extends BaseWebElement> List<T> buildComponentList(
-      List<X> listOfElements, Class<T> component, Integer indexCorrection) {
+      List<X> listOfElements, Class<T> component) {
     // Create a new list of an object that extends BaseComponent
     var listOfComponents = new ArrayList<T>();
-
-    /*
-     Default an added index correction to 0. Index correction is helpful where there are
-     elements in the list container that exist prior to the components starting. This value
-     corrects the nth-child value later on.
-     */
-    var possibleIndexCorrection = Optional.ofNullable(indexCorrection)
-            .orElse(0);
 
     /*
      Iterate through the listOfElements and create a new instance of the component, type T, to
@@ -253,15 +246,6 @@ public class BaseComponent {
             var underlyingSelector = AutomationUtils.getUnderlyingLocatorByString(elementBy);
 
             /*
-             Create a new locator that combines the parent (the underlyingLocator) and
-             an :nth-child using the index. Because the element list starts at 0, we
-             need to add 1 in order to adhere to correct CSS usage.
-             */
-            final var finalAdjustedCorrection = 1 + possibleIndexCorrection;
-            var fullNewSelector = String.format("%s:nth-child(%s)", underlyingSelector,
-                index + finalAdjustedCorrection);
-
-            /*
              Create a new instance of the component passed in by the caller. The class
              extending off of BaseComponent should not have a non-empty constructor, otherwise
              this new instance will fail to init.
@@ -274,7 +258,7 @@ public class BaseComponent {
              additional fields, such as Strings (e.g. if Strings are being used as
              locators).
              */
-            convertFieldsWithNewLocator(componentInstance, fullNewSelector);
+            convertFieldsWithNewLocator(componentInstance, underlyingSelector);
 
             /*
              After the fields have been converted on the new instance of the component,
@@ -287,24 +271,6 @@ public class BaseComponent {
           }
         });
     return listOfComponents;
-  }
-
-  /**
-   * An overloaded method of {@link #buildComponentList(List, Class, Integer)} to be used when
-   * there is no index correction required. This method sets a default of 0. Reference the method
-   * we're overloading for full documentation on usage.
-   *
-   * @param listOfElements the list of elements to iterate through and convert to components
-   * @param component      the {@link BaseComponent} class of the component we are converting the
-   *                       list of elements to
-   * @param <T>            the type reference for the components must extend {@link BaseComponent}
-   * @param <X>            the type reference for the elements we're iterating through must extend
-   *                       {@link BaseWebElement}
-   * @return as a new list of components that extend {@link BaseComponent}
-   */
-  protected <T extends BaseComponent, X extends BaseWebElement> List<T> buildComponentList(
-      List<X> listOfElements, Class<T> component) {
-    return buildComponentList(listOfElements, component, 0);
   }
 
   /**

--- a/framework/src/main/java/io/github/kgress/scaffold/BaseWebElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/BaseWebElement.java
@@ -742,6 +742,11 @@ public abstract class BaseWebElement {
     and then performs findElements() with the caller's by as the child.
      */
     elements = getRawWebElement().findElements(by);
+
+    if (elements.size() == 0) {
+      return List.of();
+    }
+
     final var childElementsByTag = getAllSiblingElementsOfElement(elements.get(0));
 
     IntStream.range(0, childElementsByTag.size())

--- a/framework/src/test/java/io/github/kgress/scaffold/MockComponent.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/MockComponent.java
@@ -25,8 +25,8 @@ public class MockComponent extends BaseComponent {
     return mockAutomationWait;
   }
 
-  public <T extends BaseComponent, X extends BaseWebElement> List<T> buildComponentList_callProtectedMethod(
-      List<X> listOfElements, Class<T> component, Integer indexCorrection) {
-    return buildComponentList(listOfElements, component, indexCorrection);
+  public <T extends BaseComponent, X extends BaseWebElement> List<T>
+  buildComponentList_callProtectedMethod(List<X> listOfElements, Class<T> component) {
+    return buildComponentList(listOfElements, component);
   }
 }

--- a/framework/src/test/java/io/github/kgress/scaffold/page/BaseComponentTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/page/BaseComponentTests.java
@@ -1,12 +1,10 @@
 package io.github.kgress.scaffold.page;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.github.kgress.scaffold.MockBaseWebElement;
 import io.github.kgress.scaffold.MockComponent;
 import io.github.kgress.scaffold.exception.ComponentException;
-import io.github.kgress.scaffold.util.AutomationUtils;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +25,7 @@ public class BaseComponentTests {
     final var listOfElements = Arrays.asList(xpathElement, xpathElement);
 
     assertThrows(ComponentException.class, () ->
-        MockComponent.buildComponentList_callProtectedMethod(listOfElements, MockComponent.class, 0));
+        MockComponent.buildComponentList_callProtectedMethod(listOfElements, MockComponent.class));
   }
 
   @Test
@@ -36,7 +34,7 @@ public class BaseComponentTests {
         By.xpath("xpath parent"));
     final var listOfElements = Arrays.asList(xpathParentElement, xpathParentElement);
     assertThrows(ComponentException.class, () ->
-        MockComponent.buildComponentList_callProtectedMethod(listOfElements, MockComponent.class, 0));
+        MockComponent.buildComponentList_callProtectedMethod(listOfElements, MockComponent.class));
   }
 
   @Test
@@ -45,38 +43,6 @@ public class BaseComponentTests {
         By.cssSelector("#css-parent"));
     final var listOfElements = Arrays.asList(xpathChildElement, xpathChildElement);
     assertThrows(ComponentException.class, () ->
-        MockComponent.buildComponentList_callProtectedMethod(listOfElements, MockComponent.class, 0));
-  }
-
-  @Test
-  public void testBuildComponentList_cssAsBy() {
-    final var expectedGetByIndex0 = "#fake-parent #fake-child:nth-child(1) #fake-field";
-    final var expectedGetByIndex1 = "#fake-parent #fake-child:nth-child(2) #fake-field";
-    final var cssParentAndChild = new MockBaseWebElement(
-        By.cssSelector("#fake-parent #fake-child"));
-    final var listOfElements = Arrays.asList(cssParentAndChild, cssParentAndChild);
-    final var output = MockComponent.buildComponentList_callProtectedMethod(listOfElements,
-        MockComponent.class, 0);
-    assertEquals(2, output.size());
-    assertEquals(expectedGetByIndex0,
-        AutomationUtils.getUnderlyingLocatorByString(output.get(0).getTestField().getBy()));
-    assertEquals(expectedGetByIndex1,
-        AutomationUtils.getUnderlyingLocatorByString(output.get(1).getTestField().getBy()));
-  }
-
-  @Test
-  public void testBuildComponentList_cssAsBy_withIndexCorrection() {
-    final var expectedGetByIndex0 = "#fake-parent #fake-child:nth-child(3) #fake-field";
-    final var expectedGetByIndex1 = "#fake-parent #fake-child:nth-child(4) #fake-field";
-    final var cssParentAndChild = new MockBaseWebElement(
-        By.cssSelector("#fake-parent #fake-child"));
-    final var listOfElements = Arrays.asList(cssParentAndChild, cssParentAndChild);
-    final var output = MockComponent.buildComponentList_callProtectedMethod(listOfElements,
-        MockComponent.class, 2);
-    assertEquals(2, output.size());
-    assertEquals(expectedGetByIndex0,
-        AutomationUtils.getUnderlyingLocatorByString(output.get(0).getTestField().getBy()));
-    assertEquals(expectedGetByIndex1,
-        AutomationUtils.getUnderlyingLocatorByString(output.get(1).getTestField().getBy()));
+        MockComponent.buildComponentList_callProtectedMethod(listOfElements, MockComponent.class));
   }
 }

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
@@ -405,125 +405,100 @@ public class BaseWebElementTests extends BaseUnitTest {
 
   // these tests use both TestBaseWebElement & MockBaseWebElement
 
-  private List<MockBaseWebElement> setupForFindElementsTests(By parentBySelector, By rootChildBySelector) {
-    final WebElement reservationCard_A = mock(WebElement.class);
-    // this mock webelement instance is necessary to distinguish from reservationCard, since the
-    // findElements method does an Object.equals to see if the instance is in the filtered list
-    // of requested items.
-    final WebElement rogueDiv = mock(WebElement.class);
-    final WebElement webElement = mock(WebElement.class);
-    when(reservationCard_A.getTagName()).thenReturn("div");
-    when(reservationCard_A.findElement(any(By.ByXPath.class))).thenReturn(webElement);
-    // order here is important, to validate that rogueDiv causes the index of the desired elements
-    // to be nonsequential
-    when(webElement.findElements(any(By.ByTagName.class))).thenReturn(
-        List.of(reservationCard_A, rogueDiv, reservationCard_A, reservationCard_A)
-    );
-    when(webElement.findElements(rootChildBySelector)).thenReturn(
-        List.of(reservationCard_A, reservationCard_A, reservationCard_A)
-    );
-    TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
-    when(parentElement.getRawWebElement()).thenReturn(webElement);
-    assertThat(parentElement).isNotNull();
-    // now assert Order of child elements is what we expect...
-    List<MockBaseWebElement> reservationCards =
-        parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
-    assertThat(reservationCards).isNotNull();
-    assertThat(reservationCards.size()).isEqualTo(3);
-    return reservationCards;
-  }
+    @Test
+    public void testBaseWebElement_findElements_by_xPath() {
+        final By parentBySelector = By.xpath("//div[@class='reservation-container']");
+        final By rootChildBySelector = By.xpath("//div[@class='reservation-card-container']");
+        final WebElement reservationCard_A = mock(WebElement.class);
+        final WebElement webElement = mock(WebElement.class);
+        when(webElement.findElements(rootChildBySelector)).thenReturn(
+            List.of(reservationCard_A, reservationCard_A, reservationCard_A)
+        );
+        TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
+        when(parentElement.getRawWebElement()).thenReturn(webElement);
+        assertThat(parentElement).isNotNull();
+        // now assert Order of child elements is what we expect...
+        List<MockBaseWebElement> reservationCards1 =
+            parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
+        assertThat(reservationCards1).isNotNull();
+        assertThat(reservationCards1.size()).isEqualTo(3);
+        final var reservationCards = reservationCards1;
+        IntStream.range(0, reservationCards.size()).forEach((i) -> {
+            switch (i) {
+                case 0:
+                    final String aByString = AutomationUtils.getUnderlyingLocatorByString(
+                        reservationCards.get(i).getBy());
+                    assertThat(aByString).isEqualTo(
+                        "//div[@class='reservation-card-container'][1]");
+                    break;
+                case 1:
+                    final String bByString = AutomationUtils.getUnderlyingLocatorByString(
+                        reservationCards.get(i).getBy());
+                    assertThat(bByString).isEqualTo(
+                        "//div[@class='reservation-card-container'][2]");
+                    break;
+                case 2:
+                    final String cByString = AutomationUtils.getUnderlyingLocatorByString(
+                        reservationCards.get(i).getBy());
+                    assertThat(cByString).isEqualTo(
+                        "//div[@class='reservation-card-container'][3]");
+                    break;
+            }
+        });
+    }
 
-  @Test
-  public void testBaseWebElement_findElements_by_xPath() {
-      final By parentBySelector = By.xpath("//div[@class='reservation-container']");
-      final By rootChildBySelector = By.xpath("//div[@class='reservation-card-container']");
-      final WebElement reservationCard_A = mock(WebElement.class);
-      final WebElement webElement = mock(WebElement.class);
-      when(webElement.findElements(rootChildBySelector)).thenReturn(
-          List.of(reservationCard_A, reservationCard_A, reservationCard_A)
-      );
-      TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
-      when(parentElement.getRawWebElement()).thenReturn(webElement);
-      assertThat(parentElement).isNotNull();
-      // now assert Order of child elements is what we expect...
-      List<MockBaseWebElement> reservationCards1 =
-          parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
-      assertThat(reservationCards1).isNotNull();
-      assertThat(reservationCards1.size()).isEqualTo(3);
-      final var reservationCards = reservationCards1;
-      IntStream.range(0, reservationCards.size()).forEach((i) -> {
-          switch (i) {
-              case 0:
-                  final String aByString = AutomationUtils.getUnderlyingLocatorByString(
-                      reservationCards.get(i).getBy());
-                  assertThat(aByString).isEqualTo("//div[@class='reservation-card-container'][1]");
-                  break;
-              case 1:
-                  final String bByString = AutomationUtils.getUnderlyingLocatorByString(
-                      reservationCards.get(i).getBy());
-                  assertThat(bByString).isEqualTo("//div[@class='reservation-card-container'][2]");
-                  break;
-              case 2:
-                  final String cByString = AutomationUtils.getUnderlyingLocatorByString(
-                      reservationCards.get(i).getBy());
-                  assertThat(cByString).isEqualTo("//div[@class='reservation-card-container'][3]");
-                  break;
-          }
-      });
-  }
-
-  @Test
-  public void testBaseWebElement_findElements_by_css() {
-    final By parentBySelector = By.cssSelector("div.reservation-container");
-    final By rootChildBySelector = By.cssSelector("div.reservation-card-container");
-      final WebElement reservationCard_A = mock(WebElement.class);
-      // this mock webelement instance is necessary to distinguish from reservationCard, since the
-      // findElements method does an Object.equals to see if the instance is in the filtered list
-      // of requested items.
-      final WebElement rogueDiv = mock(WebElement.class);
-      final WebElement webElement = mock(WebElement.class);
-      when(reservationCard_A.getTagName()).thenReturn("div");
-      when(reservationCard_A.findElement(any(By.ByXPath.class))).thenReturn(webElement);
-      // order here is important, to validate that rogueDiv causes the index of the desired elements
-      // to be nonsequential
-      when(webElement.findElements(any(By.ByTagName.class))).thenReturn(
-          List.of(reservationCard_A, rogueDiv, reservationCard_A, reservationCard_A)
-      );
-      when(webElement.findElements(rootChildBySelector)).thenReturn(
-          List.of(reservationCard_A, reservationCard_A, reservationCard_A)
-      );
-      TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
-      when(parentElement.getRawWebElement()).thenReturn(webElement);
-      assertThat(parentElement).isNotNull();
-      // now assert Order of child elements is what we expect...
-      List<MockBaseWebElement> reservationCards1 =
-          parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
-      assertThat(reservationCards1).isNotNull();
-      assertThat(reservationCards1.size()).isEqualTo(3);
-      final var reservationCards = reservationCards1;
-    IntStream.range(0, reservationCards.size()).forEach((i) -> {
-      switch (i) {
-        case 0:
-          final String aByString = AutomationUtils.getUnderlyingLocatorByString(
-              reservationCards.get(i).getBy());
-          assertThat(aByString).isEqualTo(
-              "div.reservation-container div.reservation-card-container:nth-child(1)");
-          break;
-        case 1:
-          final String bByString = AutomationUtils.getUnderlyingLocatorByString(
-              reservationCards.get(i).getBy());
-          assertThat(bByString).isEqualTo(
-              "div.reservation-container div.reservation-card-container:nth-child(3)");
-          break;
-        case 2:
-          final String cByString = AutomationUtils.getUnderlyingLocatorByString(
-              reservationCards.get(i).getBy());
-          assertThat(cByString).isEqualTo(
-              "div.reservation-container div.reservation-card-container:nth-child(4)");
-          break;
-      }
-    });
-  }
+    @Test
+    public void testBaseWebElement_findElements_by_css() {
+        final By parentBySelector = By.cssSelector("div.reservation-container");
+        final By rootChildBySelector = By.cssSelector("div.reservation-card-container");
+        final WebElement reservationCard_A = mock(WebElement.class);
+        // this mock webelement instance is necessary to distinguish from reservationCard, since the
+        // findElements method does an Object.equals to see if the instance is in the filtered list
+        // of requested items.
+        final WebElement rogueDiv = mock(WebElement.class);
+        final WebElement webElement = mock(WebElement.class);
+        when(reservationCard_A.getTagName()).thenReturn("div");
+        when(reservationCard_A.findElement(any(By.ByXPath.class))).thenReturn(webElement);
+        // order here is important, to validate that rogueDiv causes the index of the desired elements
+        // to be nonsequential
+        when(webElement.findElements(any(By.ByTagName.class))).thenReturn(
+            List.of(reservationCard_A, rogueDiv, reservationCard_A, reservationCard_A)
+        );
+        when(webElement.findElements(rootChildBySelector)).thenReturn(
+            List.of(reservationCard_A, reservationCard_A, reservationCard_A)
+        );
+        TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
+        when(parentElement.getRawWebElement()).thenReturn(webElement);
+        assertThat(parentElement).isNotNull();
+        // now assert Order of child elements is what we expect...
+        List<MockBaseWebElement> reservationCards1 =
+            parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
+        assertThat(reservationCards1).isNotNull();
+        assertThat(reservationCards1.size()).isEqualTo(3);
+        final var reservationCards = reservationCards1;
+        IntStream.range(0, reservationCards.size()).forEach((i) -> {
+            switch (i) {
+                case 0:
+                    final String aByString = AutomationUtils.getUnderlyingLocatorByString(
+                        reservationCards.get(i).getBy());
+                    assertThat(aByString).isEqualTo(
+                        "div.reservation-container div.reservation-card-container:nth-child(1)");
+                    break;
+                case 1:
+                    final String bByString = AutomationUtils.getUnderlyingLocatorByString(
+                        reservationCards.get(i).getBy());
+                    assertThat(bByString).isEqualTo(
+                        "div.reservation-container div.reservation-card-container:nth-child(3)");
+                    break;
+                case 2:
+                    final String cByString = AutomationUtils.getUnderlyingLocatorByString(
+                        reservationCards.get(i).getBy());
+                    assertThat(cByString).isEqualTo(
+                        "div.reservation-container div.reservation-card-container:nth-child(4)");
+                    break;
+            }
+        });
+    }
 
     @Test
     public void testBaseWebElement_findElements_returnsEmptyList() {

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
@@ -435,35 +435,72 @@ public class BaseWebElementTests extends BaseUnitTest {
 
   @Test
   public void testBaseWebElement_findElements_by_xPath() {
-    final By parentBySelector = By.xpath("//div[@class='reservation-container']");
-    final By rootChildBySelector = By.xpath("//div[@class='reservation-card-container']");
-    final var reservationCards = setupForFindElementsTests(parentBySelector, rootChildBySelector);
-    IntStream.range(0, reservationCards.size()).forEach((i) -> {
-      switch (i) {
-        case 0:
-          final String aByString = AutomationUtils.getUnderlyingLocatorByString(
-              reservationCards.get(i).getBy());
-          assertThat(aByString).isEqualTo("//div[@class='reservation-card-container'][1]");
-          break;
-        case 1:
-          final String bByString = AutomationUtils.getUnderlyingLocatorByString(
-              reservationCards.get(i).getBy());
-          assertThat(bByString).isEqualTo("//div[@class='reservation-card-container'][3]");
-          break;
-        case 2:
-          final String cByString = AutomationUtils.getUnderlyingLocatorByString(
-              reservationCards.get(i).getBy());
-          assertThat(cByString).isEqualTo("//div[@class='reservation-card-container'][4]");
-          break;
-      }
-    });
+      final By parentBySelector = By.xpath("//div[@class='reservation-container']");
+      final By rootChildBySelector = By.xpath("//div[@class='reservation-card-container']");
+      final WebElement reservationCard_A = mock(WebElement.class);
+      final WebElement webElement = mock(WebElement.class);
+      when(webElement.findElements(rootChildBySelector)).thenReturn(
+          List.of(reservationCard_A, reservationCard_A, reservationCard_A)
+      );
+      TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
+      when(parentElement.getRawWebElement()).thenReturn(webElement);
+      assertThat(parentElement).isNotNull();
+      // now assert Order of child elements is what we expect...
+      List<MockBaseWebElement> reservationCards1 =
+          parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
+      assertThat(reservationCards1).isNotNull();
+      assertThat(reservationCards1.size()).isEqualTo(3);
+      final var reservationCards = reservationCards1;
+      IntStream.range(0, reservationCards.size()).forEach((i) -> {
+          switch (i) {
+              case 0:
+                  final String aByString = AutomationUtils.getUnderlyingLocatorByString(
+                      reservationCards.get(i).getBy());
+                  assertThat(aByString).isEqualTo("//div[@class='reservation-card-container'][1]");
+                  break;
+              case 1:
+                  final String bByString = AutomationUtils.getUnderlyingLocatorByString(
+                      reservationCards.get(i).getBy());
+                  assertThat(bByString).isEqualTo("//div[@class='reservation-card-container'][2]");
+                  break;
+              case 2:
+                  final String cByString = AutomationUtils.getUnderlyingLocatorByString(
+                      reservationCards.get(i).getBy());
+                  assertThat(cByString).isEqualTo("//div[@class='reservation-card-container'][3]");
+                  break;
+          }
+      });
   }
 
   @Test
   public void testBaseWebElement_findElements_by_css() {
     final By parentBySelector = By.cssSelector("div.reservation-container");
     final By rootChildBySelector = By.cssSelector("div.reservation-card-container");
-    final var reservationCards = setupForFindElementsTests(parentBySelector, rootChildBySelector);
+      final WebElement reservationCard_A = mock(WebElement.class);
+      // this mock webelement instance is necessary to distinguish from reservationCard, since the
+      // findElements method does an Object.equals to see if the instance is in the filtered list
+      // of requested items.
+      final WebElement rogueDiv = mock(WebElement.class);
+      final WebElement webElement = mock(WebElement.class);
+      when(reservationCard_A.getTagName()).thenReturn("div");
+      when(reservationCard_A.findElement(any(By.ByXPath.class))).thenReturn(webElement);
+      // order here is important, to validate that rogueDiv causes the index of the desired elements
+      // to be nonsequential
+      when(webElement.findElements(any(By.ByTagName.class))).thenReturn(
+          List.of(reservationCard_A, rogueDiv, reservationCard_A, reservationCard_A)
+      );
+      when(webElement.findElements(rootChildBySelector)).thenReturn(
+          List.of(reservationCard_A, reservationCard_A, reservationCard_A)
+      );
+      TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
+      when(parentElement.getRawWebElement()).thenReturn(webElement);
+      assertThat(parentElement).isNotNull();
+      // now assert Order of child elements is what we expect...
+      List<MockBaseWebElement> reservationCards1 =
+          parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
+      assertThat(reservationCards1).isNotNull();
+      assertThat(reservationCards1.size()).isEqualTo(3);
+      final var reservationCards = reservationCards1;
     IntStream.range(0, reservationCards.size()).forEach((i) -> {
       switch (i) {
         case 0:

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
@@ -487,4 +487,24 @@ public class BaseWebElementTests extends BaseUnitTest {
       }
     });
   }
+
+    @Test
+    public void testBaseWebElement_findElements_returnsEmptyList() {
+        final By parentBySelector = By.cssSelector("div.reservation-container");
+        final By rootChildBySelector = By.cssSelector("li");
+        final WebElement webElement = mock(WebElement.class);
+        // order here is important, to validate that rogueDiv causes the index of the desired elements
+        // to be nonsequential
+        when(webElement.findElements(rootChildBySelector)).thenReturn(
+            List.of()
+        );
+        TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
+        when(parentElement.getRawWebElement()).thenReturn(webElement);
+        assertThat(parentElement).isNotNull();
+        // now assert Order of child elements is what we expect...
+        List<MockBaseWebElement> reservationCards =
+            parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
+        assertThat(reservationCards).isNotNull();
+        assertThat(reservationCards).isEmpty();
+    }
 }

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementTests.java
@@ -1,21 +1,28 @@
 package io.github.kgress.scaffold.webelement;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.github.kgress.scaffold.BaseUnitTest;
 import io.github.kgress.scaffold.MockBaseWebElement;
 import io.github.kgress.scaffold.SharedTestVariables;
+import io.github.kgress.scaffold.util.AutomationUtils;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.Test;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Point;
 import org.openqa.selenium.Rectangle;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebElement;
 
 public class BaseWebElementTests extends BaseUnitTest {
 
@@ -395,4 +402,89 @@ public class BaseWebElementTests extends BaseUnitTest {
         assertDoesNotThrow(() -> elementByCssSelector.hasClass("class"));
         assertFalse(elementByCssSelector.hasClass("class"));
     }
+
+  // these tests use both TestBaseWebElement & MockBaseWebElement
+
+  private List<MockBaseWebElement> setupForFindElementsTests(By parentBySelector, By rootChildBySelector) {
+    final WebElement reservationCard_A = mock(WebElement.class);
+    // this mock webelement instance is necessary to distinguish from reservationCard, since the
+    // findElements method does an Object.equals to see if the instance is in the filtered list
+    // of requested items.
+    final WebElement rogueDiv = mock(WebElement.class);
+    final WebElement webElement = mock(WebElement.class);
+    when(reservationCard_A.getTagName()).thenReturn("div");
+    when(reservationCard_A.findElement(any(By.ByXPath.class))).thenReturn(webElement);
+    // order here is important, to validate that rogueDiv causes the index of the desired elements
+    // to be nonsequential
+    when(webElement.findElements(any(By.ByTagName.class))).thenReturn(
+        List.of(reservationCard_A, rogueDiv, reservationCard_A, reservationCard_A)
+    );
+    when(webElement.findElements(rootChildBySelector)).thenReturn(
+        List.of(reservationCard_A, reservationCard_A, reservationCard_A)
+    );
+    TestBaseWebElement parentElement = new TestBaseWebElement(parentBySelector);
+    when(parentElement.getRawWebElement()).thenReturn(webElement);
+    assertThat(parentElement).isNotNull();
+    // now assert Order of child elements is what we expect...
+    List<MockBaseWebElement> reservationCards =
+        parentElement.findElements(MockBaseWebElement.class, rootChildBySelector);
+    assertThat(reservationCards).isNotNull();
+    assertThat(reservationCards.size()).isEqualTo(3);
+    return reservationCards;
+  }
+
+  @Test
+  public void testBaseWebElement_findElements_by_xPath() {
+    final By parentBySelector = By.xpath("//div[@class='reservation-container']");
+    final By rootChildBySelector = By.xpath("//div[@class='reservation-card-container']");
+    final var reservationCards = setupForFindElementsTests(parentBySelector, rootChildBySelector);
+    IntStream.range(0, reservationCards.size()).forEach((i) -> {
+      switch (i) {
+        case 0:
+          final String aByString = AutomationUtils.getUnderlyingLocatorByString(
+              reservationCards.get(i).getBy());
+          assertThat(aByString).isEqualTo("//div[@class='reservation-card-container'][1]");
+          break;
+        case 1:
+          final String bByString = AutomationUtils.getUnderlyingLocatorByString(
+              reservationCards.get(i).getBy());
+          assertThat(bByString).isEqualTo("//div[@class='reservation-card-container'][3]");
+          break;
+        case 2:
+          final String cByString = AutomationUtils.getUnderlyingLocatorByString(
+              reservationCards.get(i).getBy());
+          assertThat(cByString).isEqualTo("//div[@class='reservation-card-container'][4]");
+          break;
+      }
+    });
+  }
+
+  @Test
+  public void testBaseWebElement_findElements_by_css() {
+    final By parentBySelector = By.cssSelector("div.reservation-container");
+    final By rootChildBySelector = By.cssSelector("div.reservation-card-container");
+    final var reservationCards = setupForFindElementsTests(parentBySelector, rootChildBySelector);
+    IntStream.range(0, reservationCards.size()).forEach((i) -> {
+      switch (i) {
+        case 0:
+          final String aByString = AutomationUtils.getUnderlyingLocatorByString(
+              reservationCards.get(i).getBy());
+          assertThat(aByString).isEqualTo(
+              "div.reservation-container div.reservation-card-container:nth-child(1)");
+          break;
+        case 1:
+          final String bByString = AutomationUtils.getUnderlyingLocatorByString(
+              reservationCards.get(i).getBy());
+          assertThat(bByString).isEqualTo(
+              "div.reservation-container div.reservation-card-container:nth-child(3)");
+          break;
+        case 2:
+          final String cByString = AutomationUtils.getUnderlyingLocatorByString(
+              reservationCards.get(i).getBy());
+          assertThat(cByString).isEqualTo(
+              "div.reservation-container div.reservation-card-container:nth-child(4)");
+          break;
+      }
+    });
+  }
 }


### PR DESCRIPTION
Proposed fix for Issues [#138](https://github.com/kgress/scaffold/issues/138) & [#137](https://github.com/kgress/scaffold/issues/137)