### PR TITLE
feat: Support for new annotation for allowing use of hidden elements (issue #136)

### DIFF
--- a/framework/src/main/java/io/github/kgress/scaffold/BaseComponent.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/BaseComponent.java
@@ -8,7 +8,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
@@ -74,7 +73,7 @@ import org.openqa.selenium.interactions.Actions;
  * </pre>
  */
 @Slf4j
-public class BaseComponent {
+public class BaseComponent extends WebElementAnnotationProcessor {
 
   /**
    * Builds a list of a {@link BaseComponent}'s using an already found list of elements from a

--- a/framework/src/main/java/io/github/kgress/scaffold/HiddenElement.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/HiddenElement.java
@@ -1,0 +1,10 @@
+package io.github.kgress.scaffold;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface HiddenElement { }

--- a/framework/src/main/java/io/github/kgress/scaffold/WebElementAnnotationProcessor.java
+++ b/framework/src/main/java/io/github/kgress/scaffold/WebElementAnnotationProcessor.java
@@ -1,0 +1,35 @@
+package io.github.kgress.scaffold;
+
+import java.lang.reflect.Field;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * This class provides a framework to retrieve annotations applied at the Field level and then pass them down
+ * to a child object instance in the object graph.
+ */
+@Slf4j
+abstract class WebElementAnnotationProcessor {
+
+  /**
+   * This method looks at each field on the class and if is decorated with annotations,
+   * passes the annotations to the value of the field.  This currently only applies to fields
+   * that have values that derive from {@link BaseWebElement}. The {@link BaseWebElement} will evaluate the provided
+   * annotations.
+   */
+  protected void applyFieldAnnotations() {
+    final var clazz = getClass();
+    for (Field field : clazz.getDeclaredFields()) {
+      field.setAccessible(true);
+      final var annotations = field.getAnnotations();
+      try {
+        final var fieldValue = field.get(this);
+        if (fieldValue instanceof BaseWebElement) {
+          ((BaseWebElement) fieldValue).evaluateAppliedAnnotations(annotations);
+        }
+      } catch (IllegalAccessException ex) {
+        log.error(String.format("Error getting field value for field '%s'.", field.getName()), ex);
+      }
+    }
+  }
+
+}

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementLoggerTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/BaseWebElementLoggerTests.java
@@ -39,9 +39,9 @@ public class BaseWebElementLoggerTests {
     final var logLevel = testLogger.getLoggingEvents().get(0).getLevel();
     assertEquals(Level.WARN, logLevel);
     assertEquals(String.format("It is strongly recommended to use a CSS selector for element "
-        + "[%s] instead of XPATH when instantiating new Scaffold elements. Failure in "
-        + "using a CSS selector may hinder the availability of functionality on the "
-        + "element.", mockBaseWebElement.getBy()), exceptionMessage);
+        + "parent [%s] and element child [%s] instead of XPATH when instantiating new "
+        + "Scaffold elements. Failure in using a CSS selector may hinder the availability "
+        + "of functionality on the element.", null, mockBaseWebElement.getBy()), exceptionMessage);
   }
 
   @Test

--- a/framework/src/test/java/io/github/kgress/scaffold/webelement/HiddenElementTests.java
+++ b/framework/src/test/java/io/github/kgress/scaffold/webelement/HiddenElementTests.java
@@ -1,0 +1,59 @@
+package io.github.kgress.scaffold.webelement;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.kgress.scaffold.BaseComponent;
+import io.github.kgress.scaffold.BaseUnitTest;
+import io.github.kgress.scaffold.HiddenElement;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+
+@Slf4j
+public class HiddenElementTests extends BaseUnitTest {
+
+  class TestComponent extends BaseComponent {
+
+    @HiddenElement
+    private final TestBaseWebElement hiddenThing = new TestBaseWebElement(
+        By.cssSelector(".hiddenElement"));
+
+    private final TestBaseWebElement notHiddenThing = new TestBaseWebElement(
+        By.cssSelector(".notHidden"));
+
+    public TestComponent() {
+      super();
+      applyFieldAnnotations();
+    }
+
+    public TestBaseWebElement getHiddenThing() {
+      return hiddenThing;
+    }
+
+    public TestBaseWebElement getNotHiddenThing() {
+      return notHiddenThing;
+    }
+  }
+
+  @Test
+  public void testHiddenElement() {
+    final var testComponent = new TestComponent();
+    when(testComponent.hiddenThing.getRawWebElement()).thenReturn(mock(WebElement.class));
+    testComponent.getHiddenThing().getText();
+    verifyNoInteractions(testComponent.hiddenThing.getWebElementWait());
+  }
+
+  @Test
+  public void testNotHiddenElement() {
+    final var testComponent = new TestComponent();
+    when(testComponent.notHiddenThing.getRawWebElement()).thenReturn(mock(WebElement.class));
+    testComponent.getNotHiddenThing().getText();
+    verify(testComponent.notHiddenThing.getWebElementWait(), times(2)).waitUntilDisplayed();
+  }
+
+}


### PR DESCRIPTION
An implementation to add the requested feature of a `HiddenElement` annotation that will allow the bypass of `waitUntilDisplayed()`.